### PR TITLE
Add Wifi wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ services are enabled by default:
 started by default if a supporting interface is discovered on the device
 * **mDNS** - supports `nerves.local` and the default hostname (i.e. `nerves-1234.local`)
 This is also configurable to other hostnames as well.
+* **WiFi Setup Wizard** - Utilizing `VintageNetWizard` to set device to AP host mode to
+provide a website for configuring WiFi networks from a broswer. This is enabled by default
+if `wlan` interface is available but not configured previously or by `config.exs`.
+See [`vintage_net_wizard` library](https://github.com/nerves-networking/vintage_net_wizard) for more info.
 * **SSH** - Includes SSH access, firmware updates over SSH, and SFTP
+* **Circuits GPIO** - Interfacing with GPIO via [`circuits_gpio`](https://github.com/elixir-circuits/circuits_gpio)
 
 ## Installation
 

--- a/lib/nerves_pack.ex
+++ b/lib/nerves_pack.ex
@@ -8,6 +8,11 @@ defmodule NervesPack do
   started by default if a supporting interface is discovered on the device
   * **mDNS** - supports `nerves.local` and the default hostname (i.e. `nerves-1234.local`)
   This is also configurable to other hostnames as well.
+  * **WiFi Setup Wizard** - Utilizing `VintageNetWizard` to set device to AP host mode to
+  provide a website for configuring WiFi networks from a broswer. This is enabled by default
+  if `wlan` interface is available but not configured previously or by `config.exs`.
+  See [`vintage_net_wizard` library](https://github.com/nerves-networking/vintage_net_wizard) for more info.
   * **SSH** - Includes SSH access, firmware updates over SSH, and SFTP
+  * **Circuits GPIO** - Interfacing with GPIO via [`circuits_gpio`](https://github.com/elixir-circuits/circuits_gpio)
   """
 end

--- a/lib/nerves_pack/application.ex
+++ b/lib/nerves_pack/application.ex
@@ -4,34 +4,67 @@ defmodule NervesPack.Application do
   use Application
   require Logger
 
-  alias VintageNet.Technology.{Ethernet, Gadget, WiFi}
+  alias VintageNet.Technology.{Ethernet, Gadget}
 
   def start(_type, _args) do
     configure_networking()
 
-    children = [
-      NervesPack.SSH
-    ]
+    children =
+      [NervesPack.SSH]
+      |> add_wifi_wizard_button()
 
     opts = [strategy: :one_for_one, name: NervesPack.Supervisor]
     Supervisor.start_link(children, opts)
   end
 
-  defp configure_networking() do
-    configured = VintageNet.configured_interfaces()
-    all = VintageNet.all_interfaces() |> Enum.reject(&String.starts_with?(&1, "lo"))
-
-    for ifname <- all, ifname not in configured do
-      if type = type_for_ifname(ifname) do
-        VintageNet.configure(ifname, %{type: type})
-      else
-        Logger.warn("[NervesPack] unsupported default network interface: #{ifname}")
-      end
+  defp add_wifi_wizard_button(children) do
+    if Application.get_env(:nerves_pack, :wifi_wizard_button, true) do
+      [NervesPack.WiFiWizardButton | children]
+    else
+      children
     end
   end
 
-  defp type_for_ifname("eth" <> _), do: Ethernet
-  defp type_for_ifname("usb" <> _), do: Gadget
-  defp type_for_ifname("wlan" <> _), do: WiFi
-  defp type_for_ifname(_), do: nil
+  defp configure_networking() do
+    configured = VintageNet.configured_interfaces()
+
+    all =
+      VintageNet.all_interfaces()
+      |> Enum.reject(&String.starts_with?(&1, "lo"))
+
+    for ifname <- all, ifname not in configured do
+      case ifname do
+        "eth" <> _ ->
+          VintageNet.configure(ifname, %{type: Ethernet})
+
+        "usb" <> _ ->
+          VintageNet.configure(ifname, %{type: Gadget})
+
+        "wlan" <> _ ->
+          VintageNetWizard.run_wizard()
+
+          Logger.info("""
+          [NervesPack] WiFi interface is available on wlan0, but not configured.
+          For convenience, the WiFi Wizard has been started and networks can be
+          setup via the web interface. To do so, connect to your device's network,
+          then open a browser to one of the supported addresses to complete setup:
+
+          * configured device hostname (i.e. http://nerves.local)
+          * default device hostname (i.e. http://nerves-ac23.local)
+          * http://wifi.config
+          * http://192.168.0.1
+
+          If your device supports USB Gadget, you can also skip joining its broadcasted
+          network and use the device hostname in a browser to continue setup.
+
+          For more info, see https://github.com/nerves-networking/vintage_net_wizard
+          """)
+
+        _ ->
+          Logger.warn(
+            "[NervesPack] No default interface configuration is available for #{ifname} - Skipping.."
+          )
+      end
+    end
+  end
 end

--- a/lib/nerves_pack/wifi_wizard_button.ex
+++ b/lib/nerves_pack/wifi_wizard_button.ex
@@ -1,0 +1,85 @@
+defmodule NervesPack.WiFiWizardButton do
+  use GenServer
+
+  @moduledoc """
+  This GenServer starts the wizard if a button is depressed for long enough.
+
+  GPIO 26 is used for the button and the hold time is 5 seconds.
+  These defaults can be configured in the config if desired:
+
+  ```
+  config :nerves_pack,
+    wifi_wizard_button_pin: 17,
+    wifi_wizard_button_hold: 3_000
+  ```
+
+  You can also disable using a button to start the WiFi wizard
+  in the config as well:
+
+  ```
+  config :nerves_pack, wifi_wizard_button: false
+  ```
+  """
+
+  alias Circuits.GPIO
+
+  require Logger
+
+  @doc """
+  Start the button monitor
+  """
+  @spec start_link(list()) :: GenServer.on_start()
+  def start_link(_opts \\ []) do
+    gpio_pin = Application.get_env(:nerves_pack, :wifi_wizard_button_pin, 26)
+    GenServer.start_link(__MODULE__, gpio_pin, name: __MODULE__)
+  end
+
+  @impl true
+  def init(gpio_pin) do
+    {:ok, gpio} = GPIO.open(gpio_pin, :input)
+    :ok = GPIO.set_interrupts(gpio, :both)
+
+    timeout =
+      Application.get_env(:nerves_pack, :wifi_wizard_button_hold, 5_000)
+      |> validate_timeout()
+
+    Logger.info("""
+    [NervesPack] WiFi Wizard can be started any time by pressing down the button
+    on GPIO #{gpio_pin} for #{timeout / 1000} seconds.
+
+    If no button is connected, you can manually mock a "press" by connecting the
+    pin to 3.3v power for the required time with a cable.
+    """)
+
+    {:ok, %{button_timeout: timeout, pin: gpio_pin, gpio: gpio}}
+  end
+
+  @impl true
+  def handle_info({:circuits_gpio, gpio_pin, _timestamp, 1}, %{pin: gpio_pin} = state) do
+    # Button pressed. Start a timer to launch the wizard when it's long enough
+    {:noreply, state, state.button_timeout}
+  end
+
+  @impl true
+  def handle_info({:circuits_gpio, gpio_pin, _timestamp, 0}, %{pin: gpio_pin} = state) do
+    # Button released. The GenServer timer is implicitly cancelled by receiving this message.
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:timeout, state) do
+    # Timeout occurred before button released which means
+    # it was held for long enough
+    :ok = VintageNetWizard.run_wizard()
+    Logger.info("[NervesPack] WiFi Wizard started...")
+    {:noreply, state}
+  end
+
+  defp validate_timeout(timeout) when is_integer(timeout), do: timeout
+
+  defp validate_timeout(timeout) do
+    Logger.warn(
+      "[NervesPack] Invalid button hold: #{inspect(timeout)}. Must be an integer in ms. Using default 5_000"
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule NervesPack.MixProject do
   defp deps do
     [
       {:busybox, "~> 0.1"},
+      {:circuits_gpio, "~> 0.4"},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false},
       {:mdns_lite, "~> 0.2"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{
+  "busybox": {:hex, :busybox, "0.1.3", "539dba9c63e4a9a43ad55ddc7985faec9cbad997c339cd1a3de2264ce3848d39", [:make, :mix], [{:elixir_make, "~> 0.5", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "circuits_gpio": {:hex, :circuits_gpio, "0.4.3", "1a53dff1eaeefb9f67f4ebc2c1852b603683eedaa6053bed51c038dd64b978bb", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.7.0", "91ed100138a764355f43316b1d23d7ff6bdb0de4ea618cb5d8677c93a7a2f115", [:rebar3], [{:cowlib, "~> 2.8.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.8.0", "fd0ff1787db84ac415b8211573e9a30a3ebe71b5cbff7f720089972b2319c8a4", [:rebar3], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Adds support to use `VintageNetWizard` when wlan is available but not configured.
Also starts a button monitor by default so the wizard can be started by pressing a button
for a certain period of time.