### PR TITLE
Dont use WifiWizardButton by default

### DIFF
--- a/lib/nerves_pack/application.ex
+++ b/lib/nerves_pack/application.ex
@@ -19,7 +19,7 @@ defmodule NervesPack.Application do
   end
 
   defp add_wifi_wizard_button(children) do
-    if Application.get_env(:nerves_pack, :wifi_wizard_button, true) do
+    if Application.get_env(:nerves_pack, :wifi_wizard_button, false) do
       [NervesPack.WiFiWizardButton | children]
     else
       children

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule NervesPack.MixProject do
   defp deps do
     [
       {:busybox, "~> 0.1"},
-      {:circuits_gpio, "~> 0.4"},
+      {:circuits_gpio, "~> 0.4", optional: true},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false},
       {:mdns_lite, "~> 0.6"},


### PR DESCRIPTION
Makes circuits_gpio optional and the wizard button unused by default. If others want to use, they can add the required dep or copy/paste code as a starting point.